### PR TITLE
Display partial transcriptions in the UI, but only translate the final ones

### DIFF
--- a/webapp/adapters/transcribeAdapter.js
+++ b/webapp/adapters/transcribeAdapter.js
@@ -70,10 +70,11 @@ export async function getAmazonTranscribeClientCustomer() {
   }
 }
 
-export async function startCustomerStreamTranscription(audioStream, languageCode, onTranscribeEvent) {
+export async function startCustomerStreamTranscription(audioStream, languageCode, onFinalTranscribeEvent, onPartialTranscribeEvent) {
   if (isObjectUndefinedNullEmpty(audioStream)) throw new Error("audioStream is required");
   if (isStringUndefinedNullEmpty(languageCode)) throw new Error("languageCode is required");
-  if (isFunction(onTranscribeEvent)) throw new Error("onTranscribeEvent is required");
+  if (isFunction(onFinalTranscribeEvent)) throw new Error("onFinalTranscribeEvent is required");
+  if (isFunction(onPartialTranscribeEvent)) throw new Error("onPartialTranscribeEvent is required");
 
   const startStreamTranscriptionCommand = new StartStreamTranscriptionCommand({
     LanguageCode: languageCode,
@@ -87,17 +88,23 @@ export async function startCustomerStreamTranscription(audioStream, languageCode
 
   for await (const event of startStreamTranscriptionResponse.TranscriptResultStream) {
     const results = event.TranscriptEvent.Transcript.Results;
-    if (results.length && !results[0]?.IsPartial) {
-      const newTranscript = results[0].Alternatives[0].Transcript;
-      onTranscribeEvent(newTranscript);
+    if (results?.length > 0) {
+      if (results[0]?.IsPartial === true) {
+        const partialTranscript = results[0].Alternatives[0].Transcript;
+        onPartialTranscribeEvent(partialTranscript);
+      } else {
+        const newTranscript = results[0].Alternatives[0].Transcript;
+        onFinalTranscribeEvent(newTranscript);
+      }
     }
   }
 }
 
-export async function startAgentStreamTranscription(audioStream, languageCode, onTranscribeEvent) {
+export async function startAgentStreamTranscription(audioStream, languageCode, onFinalTranscribeEvent, onPartialTranscribeEvent) {
   if (isObjectUndefinedNullEmpty(audioStream)) throw new Error("audioStream is required");
   if (isStringUndefinedNullEmpty(languageCode)) throw new Error("languageCode is required");
-  if (isFunction(onTranscribeEvent)) throw new Error("onTranscribeEvent is required");
+  if (isFunction(onFinalTranscribeEvent)) throw new Error("onFinalTranscribeEvent is required");
+  if (isFunction(onPartialTranscribeEvent)) throw new Error("onPartialTranscribeEvent is required");
 
   const startStreamTranscriptionCommand = new StartStreamTranscriptionCommand({
     LanguageCode: languageCode,
@@ -111,9 +118,14 @@ export async function startAgentStreamTranscription(audioStream, languageCode, o
 
   for await (const event of startStreamTranscriptionResponse.TranscriptResultStream) {
     const results = event.TranscriptEvent.Transcript.Results;
-    if (results.length && !results[0]?.IsPartial) {
-      const newTranscript = results[0].Alternatives[0].Transcript;
-      onTranscribeEvent(newTranscript);
+    if (results?.length > 0) {
+      if (results[0]?.IsPartial === true) {
+        const partialTranscript = results[0].Alternatives[0].Transcript;
+        onPartialTranscribeEvent(partialTranscript);
+      } else {
+        const newTranscript = results[0].Alternatives[0].Transcript;
+        onFinalTranscribeEvent(newTranscript);
+      }
     }
   }
 }

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -82,7 +82,7 @@
                   <button id="customerTranscribeLanguageSaveButton">Save</button>
                 </div>
                 <div class="button-group">
-                  <button id="customerStartTranscriptionButton">Start Transcription</button>
+                  <button id="customerStartTranscriptionButton" disabled>Start Transcription</button>
                   <button id="customerStopTranscriptionButton" disabled>Stop Transcription</button>
                 </div>
                 <div class="checkbox-group">
@@ -159,7 +159,7 @@
                   <button id="agentTranscribeLanguageSaveButton">Save</button>
                 </div>
                 <div class="button-group">
-                  <button id="agentStartTranscriptionButton">Start Transcription</button>
+                  <button id="agentStartTranscriptionButton" disabled>Start Transcription</button>
                   <button id="agentStopTranscriptionButton" disabled>Stop Transcription</button>
                   <button id="agentMuteTranscriptionButton">Mute</button>
                 </div>

--- a/webapp/style.css
+++ b/webapp/style.css
@@ -274,3 +274,15 @@ button:disabled {
       flex-basis: 100%;
   }
 }
+
+.bg-pale-green {
+  background-color: #e8f5e9;  /* Pale green color */
+}
+
+.bg-pale-yellow {
+  background-color: #fffde7;  /* Pale yellow color */
+}
+
+.bg-none {
+  background-color: transparent;
+}


### PR DESCRIPTION
This PR enables displaying partial transcriptions in the UI, for the faster visual feedback, but it still translates only the final transcriptions, to avoid compromising the translation accuracy.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
